### PR TITLE
Push the ev dependency from fmidi-player to fmidi-play

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@ list(APPEND CMAKE_MODULE_PATH "${cmake_MODULE_DIR}")
 option(FMIDI_ENABLE_DEBUG "enable debugging features" OFF)
 option(FMIDI_PIC "enable position independent code" ON)
 option(FMIDI_STATIC "build as static library" ON)
-option(FMIDI_PLAYER_LIBRARY "Build the fmidi-player library for callback-based playing of midi files" ON)
 
 if(FMIDI_ENABLE_DEBUG)
   add_definitions("-DFMIDI_DEBUG=1")
@@ -41,24 +40,23 @@ if(Boost_FOUND)
   add_definitions("-DFMIDI_USE_BOOST")
 endif()
 
-find_library(ev_LIBRARY ev)
 
 set(fmidi-play_BUILD FALSE)
-if(FMIDI_PLAYER_LIBRARY)
-  include(FindPkgConfig)
-  find_package(Curses)
-  pkg_check_modules(rtmidi rtmidi)
-  if(NOT rtmidi_FOUND)
-    message(STATUS "rtmidi is missing, NOT building program fmidi-play.")
-  elseif (NOT CURSES_FOUND)
-    message(STATUS "curses is missing, NOT building program fmidi-play.")
-  elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows" AND NOT (Boost_FOUND AND Boost_FILESYSTEM_LIBRARY AND Boost_SYSTEM_LIBRARY))
-    message(STATUS "Boost is missing, NOT building program fmidi-play.")
-  elseif(NOT ev_LIBRARY)
-    message(STATUS "libev is missing, NOT building program fmidi-play.")
-  else()
-    set(fmidi-play_BUILD TRUE)
-  endif()
+find_library(ev_LIBRARY ev)
+
+include(FindPkgConfig)
+find_package(Curses)
+pkg_check_modules(rtmidi rtmidi)
+if(NOT rtmidi_FOUND)
+  message(STATUS "rtmidi is missing, NOT building program fmidi-play.")
+elseif (NOT CURSES_FOUND)
+  message(STATUS "curses is missing, NOT building program fmidi-play.")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows" AND NOT (Boost_FOUND AND Boost_FILESYSTEM_LIBRARY AND Boost_SYSTEM_LIBRARY))
+  message(STATUS "Boost is missing, NOT building program fmidi-play.")
+elseif(NOT ev_LIBRARY)
+  message(STATUS "libev is missing, NOT building program fmidi-play.")
+else()
+  set(fmidi-play_BUILD TRUE)
 endif()
 
 include(CheckCSourceCompiles)
@@ -95,8 +93,7 @@ set(fmidi_SOURCES
   sources/fmidi/file/identify.cc
   sources/fmidi/fmidi_internal.cc
   sources/fmidi/fmidi_seq.cc
-  sources/fmidi/fmidi_util.cc)
-set(fmidi-player_SOURCES
+  sources/fmidi/fmidi_util.cc
   sources/fmidi/fmidi_player.cc)
 
 add_library(fmidi "${fmidi_LIB_TYPE}" ${fmidi_SOURCES})
@@ -120,23 +117,6 @@ install(TARGETS fmidi
 install(FILES sources/fmidi/fmidi.h
   DESTINATION "include")
 
-if(FMIDI_PLAYER_LIBRARY)
-  add_library(fmidi-player "${fmidi_LIB_TYPE}" ${fmidi-player_SOURCES})
-  target_compile_definitions(fmidi-player
-    PRIVATE "FMIDI_BUILD=1")
-  set_target_properties(fmidi-player PROPERTIES
-    CXX_VISIBILITY_PRESET "hidden"
-    SOVERSION 0.1)
-  if(FMIDI_PIC)
-    set_target_properties(fmidi-player PROPERTIES
-      POSITION_INDEPENDENT_CODE ON)
-  endif()
-  install(TARGETS fmidi-player
-    RUNTIME DESTINATION "bin"
-    LIBRARY DESTINATION "lib"
-    ARCHIVE DESTINATION "lib")
-endif()
-
 ###################
 # PKGCONFIG FILES #
 ###################
@@ -154,23 +134,6 @@ Libs: -L\${libdir} -lfmidi
 ")
 install(FILES "${CMAKE_BINARY_DIR}/fmidi.pc"
   DESTINATION "lib/pkgconfig")
-
-if(FMIDI_PLAYER_LIBRARY)
-  file(GENERATE OUTPUT "${CMAKE_BINARY_DIR}/fmidi-player.pc"
-    CONTENT "prefix=${CMAKE_INSTALL_PREFIX}
-libdir=\${prefix}/lib
-includedir=\${prefix}/include
-
-Name: fmidi-player
-Description: A MIDI file playback library
-Version: ${PROJECT_VERSION}
-Cflags: -I\${includedir}
-Libs: -L\${libdir} -lfmidi-player
-Libs.private: -lev
-")
-  install(FILES "${CMAKE_BINARY_DIR}/fmidi-player.pc"
-    DESTINATION "lib/pkgconfig")
-endif()
 
 ############
 # PROGRAMS #
@@ -194,9 +157,7 @@ install(TARGETS fmidi-convert
 if(fmidi-play_BUILD)
   add_executable(fmidi-play programs/midi-play.cc programs/playlist.cc)
   target_link_libraries(fmidi-play
-  PRIVATE fmidi-player fmidi ${rtmidi_LIBRARIES} ${CURSES_LIBRARIES})
-  target_link_libraries(fmidi-play
-    PRIVATE fmidi-player ${ev_LIBRARY})
+  PRIVATE fmidi ${rtmidi_LIBRARIES} ${CURSES_LIBRARIES} ${ev_LIBRARY})
   target_include_directories(fmidi-play
     PRIVATE ${rtmidi_INCLUDE_DIRS} ${CURSES_INCLUDE_DIRS})
   link_directories(${rtmidi_LIBRARY_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ list(APPEND CMAKE_MODULE_PATH "${cmake_MODULE_DIR}")
 option(FMIDI_ENABLE_DEBUG "enable debugging features" OFF)
 option(FMIDI_PIC "enable position independent code" ON)
 option(FMIDI_STATIC "build as static library" ON)
+option(FMIDI_PLAYER_LIBRARY "Build the fmidi-player library for callback-based playing of midi files" ON)
 
 if(FMIDI_ENABLE_DEBUG)
   add_definitions("-DFMIDI_DEBUG=1")
@@ -41,15 +42,9 @@ if(Boost_FOUND)
 endif()
 
 find_library(ev_LIBRARY ev)
-set(fmidi-player_BUILD FALSE)
-if(ev_LIBRARY)
-  set(fmidi-player_BUILD TRUE)
-else()
-  message(STATUS "libev is missing, NOT building library fmidi-player.")
-endif()
 
 set(fmidi-play_BUILD FALSE)
-if(fmidi-player_BUILD)
+if(FMIDI_PLAYER_LIBRARY)
   include(FindPkgConfig)
   find_package(Curses)
   pkg_check_modules(rtmidi rtmidi)
@@ -59,6 +54,8 @@ if(fmidi-player_BUILD)
     message(STATUS "curses is missing, NOT building program fmidi-play.")
   elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows" AND NOT (Boost_FOUND AND Boost_FILESYSTEM_LIBRARY AND Boost_SYSTEM_LIBRARY))
     message(STATUS "Boost is missing, NOT building program fmidi-play.")
+  elseif(NOT ev_LIBRARY)
+    message(STATUS "libev is missing, NOT building program fmidi-play.")
   else()
     set(fmidi-play_BUILD TRUE)
   endif()
@@ -123,12 +120,10 @@ install(TARGETS fmidi
 install(FILES sources/fmidi/fmidi.h
   DESTINATION "include")
 
-if(fmidi-player_BUILD)
+if(FMIDI_PLAYER_LIBRARY)
   add_library(fmidi-player "${fmidi_LIB_TYPE}" ${fmidi-player_SOURCES})
   target_compile_definitions(fmidi-player
     PRIVATE "FMIDI_BUILD=1")
-  target_link_libraries(fmidi-player
-    PUBLIC fmidi "${ev_LIBRARY}")
   set_target_properties(fmidi-player PROPERTIES
     CXX_VISIBILITY_PRESET "hidden"
     SOVERSION 0.1)
@@ -160,7 +155,7 @@ Libs: -L\${libdir} -lfmidi
 install(FILES "${CMAKE_BINARY_DIR}/fmidi.pc"
   DESTINATION "lib/pkgconfig")
 
-if(fmidi-player_BUILD)
+if(FMIDI_PLAYER_LIBRARY)
   file(GENERATE OUTPUT "${CMAKE_BINARY_DIR}/fmidi-player.pc"
     CONTENT "prefix=${CMAKE_INSTALL_PREFIX}
 libdir=\${prefix}/lib
@@ -199,7 +194,9 @@ install(TARGETS fmidi-convert
 if(fmidi-play_BUILD)
   add_executable(fmidi-play programs/midi-play.cc programs/playlist.cc)
   target_link_libraries(fmidi-play
-    PRIVATE fmidi-player ${rtmidi_LIBRARIES} ${CURSES_LIBRARIES})
+  PRIVATE fmidi-player fmidi ${rtmidi_LIBRARIES} ${CURSES_LIBRARIES})
+  target_link_libraries(fmidi-play
+    PRIVATE fmidi-player ${ev_LIBRARY})
   target_include_directories(fmidi-play
     PRIVATE ${rtmidi_INCLUDE_DIRS} ${CURSES_INCLUDE_DIRS})
   link_directories(${rtmidi_LIBRARY_DIRS})


### PR DESCRIPTION
The fmidi player library (in `fmidi_player.cc`) actually does not depend on libev. This patch adds an option to eventually disable the player library, and moves the dependency checker for libev to the `fmidi-play` program. Given that the header is the same, maybe the fmidi-player library should just be merged with the fmidi library?