### PR TITLE
Add basic hand-written man pages for the command-line tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,16 +155,22 @@ if(FMIDI_PROGRAMS)
   target_link_libraries(fmidi-read PRIVATE fmidi fmidi-fmt)
   install(TARGETS fmidi-read
     RUNTIME DESTINATION "bin")
+  install(FILES "${PROJECT_SOURCE_DIR}/man/fmidi-read.1"
+    DESTINATION "share/man/man1")
 
   add_executable(fmidi-seq programs/midi-seq.cc)
   target_link_libraries(fmidi-seq PRIVATE fmidi fmidi-fmt)
   install(TARGETS fmidi-seq
     RUNTIME DESTINATION "bin")
+  install(FILES "${PROJECT_SOURCE_DIR}/man/fmidi-seq.1"
+    DESTINATION "share/man/man1")
 
   add_executable(fmidi-convert programs/midi-convert.cc)
   target_link_libraries(fmidi-convert PRIVATE fmidi fmidi-fmt)
   install(TARGETS fmidi-convert
     RUNTIME DESTINATION "bin")
+  install(FILES "${PROJECT_SOURCE_DIR}/man/fmidi-convert.1"
+    DESTINATION "share/man/man1")
 
   if(fmidi-play_BUILD)
     add_executable(fmidi-play programs/midi-play.cc programs/playlist.cc)
@@ -175,6 +181,8 @@ if(FMIDI_PROGRAMS)
     link_directories(${rtmidi_LIBRARY_DIRS})
     install(TARGETS fmidi-play
       RUNTIME DESTINATION "bin")
+    install(FILES "${PROJECT_SOURCE_DIR}/man/fmidi-play.1"
+      DESTINATION "share/man/man1")
     if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
       target_compile_definitions(fmidi-play PRIVATE "FMIDI_PLAY_USE_BOOST_FILESYSTEM=")
       target_link_libraries(fmidi-play PRIVATE "${Boost_FILESYSTEM_LIBRARY}" "${Boost_SYSTEM_LIBRARY}")
@@ -186,5 +194,7 @@ if(FMIDI_PROGRAMS)
     target_link_libraries(fmidi-grep PRIVATE fmidi fmidi-fmt)
     install(TARGETS fmidi-grep
       RUNTIME DESTINATION "bin")
+    install(FILES "${PROJECT_SOURCE_DIR}/man/fmidi-grep.1"
+      DESTINATION "share/man/man1")
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,21 +155,21 @@ if(FMIDI_PROGRAMS)
   target_link_libraries(fmidi-read PRIVATE fmidi fmidi-fmt)
   install(TARGETS fmidi-read
     RUNTIME DESTINATION "bin")
-  install(FILES "${PROJECT_SOURCE_DIR}/man/fmidi-read.1"
+  install(FILES "man/fmidi-read.1"
     DESTINATION "share/man/man1")
 
   add_executable(fmidi-seq programs/midi-seq.cc)
   target_link_libraries(fmidi-seq PRIVATE fmidi fmidi-fmt)
   install(TARGETS fmidi-seq
     RUNTIME DESTINATION "bin")
-  install(FILES "${PROJECT_SOURCE_DIR}/man/fmidi-seq.1"
+  install(FILES "man/fmidi-seq.1"
     DESTINATION "share/man/man1")
 
   add_executable(fmidi-convert programs/midi-convert.cc)
   target_link_libraries(fmidi-convert PRIVATE fmidi fmidi-fmt)
   install(TARGETS fmidi-convert
     RUNTIME DESTINATION "bin")
-  install(FILES "${PROJECT_SOURCE_DIR}/man/fmidi-convert.1"
+  install(FILES "man/fmidi-convert.1"
     DESTINATION "share/man/man1")
 
   if(fmidi-play_BUILD)
@@ -181,7 +181,7 @@ if(FMIDI_PROGRAMS)
     link_directories(${rtmidi_LIBRARY_DIRS})
     install(TARGETS fmidi-play
       RUNTIME DESTINATION "bin")
-    install(FILES "${PROJECT_SOURCE_DIR}/man/fmidi-play.1"
+    install(FILES "man/fmidi-play.1"
       DESTINATION "share/man/man1")
     if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
       target_compile_definitions(fmidi-play PRIVATE "FMIDI_PLAY_USE_BOOST_FILESYSTEM=")
@@ -194,7 +194,7 @@ if(FMIDI_PROGRAMS)
     target_link_libraries(fmidi-grep PRIVATE fmidi fmidi-fmt)
     install(TARGETS fmidi-grep
       RUNTIME DESTINATION "bin")
-    install(FILES "${PROJECT_SOURCE_DIR}/man/fmidi-grep.1"
+    install(FILES "man/fmidi-grep.1"
       DESTINATION "share/man/man1")
   endif()
 endif()

--- a/man/fmidi-convert.1
+++ b/man/fmidi-convert.1
@@ -1,0 +1,17 @@
+.TH FMIDI\-CONVERT "1" "August 2021" "" "User Commands"
+.SH NAME
+fmidi\-convert \(en convert to Standard Midi Files (SMF)
+.SH SYNOPSIS
+.B fmidi\-convert
+.I INPUT
+.P
+Converts an
+.I INPUT
+file in any supported format to Standard Midi Files (SMF) format and writes the result on
+.BR stdout .
+The output should be redirected to a file or piped to another command.
+.SH "SEE\ ALSO"
+.BR fmidi\-grep (1),
+.BR fmidi\-play (1),
+.BR fmidi\-read (1),
+.BR fmidi\-seq (1)

--- a/man/fmidi-grep.1
+++ b/man/fmidi-grep.1
@@ -1,0 +1,31 @@
+.TH FMIDI\-GREP "1" "August 2021" "" "User Commands"
+.SH NAME
+fmidi\-grep \(en search for pattern matches in one or more input files
+.SH SYNOPSIS
+.B fmidi\-grep
+.RI [ OPTION \ ...]
+.I PATTERN
+.I INPUT
+.RI [ INPUT \ ...]
+.P
+Searches for pattern matches in one or more
+.I INPUT
+files and writes results on
+.BR stdout .
+.SH OPTIONS
+.TP
+.B \-r\fR,\fB\-R
+recursive
+.TP
+.B \-E
+extended pattern
+.TP
+.B \-F
+fixed string pattern
+.SH "SEE\ ALSO"
+.BR fmidi\-convert (1),
+.BR fmidi\-play (1),
+.BR fmidi\-read (1),
+.BR fmidi\-seq (1)
+.P
+.BR grep (1)

--- a/man/fmidi-play.1
+++ b/man/fmidi-play.1
@@ -21,7 +21,7 @@ Specify MIDI client name (default
 .TP
 .B \-M\ \fR[\fBalsa\fR|\fBjack\fR]
 Choose a particular MIDI API for playback; default is unspecified, allowing the
-RtMidi library to choose.
+implementation to choose.
 .TP
 .B \-L\fR\ \fILOG
 Write a playback log to the given

--- a/man/fmidi-play.1
+++ b/man/fmidi-play.1
@@ -1,0 +1,34 @@
+.TH FMIDI\-PLAY "1" "August 2021" "" "User Commands"
+.SH NAME
+fmidi\-play \(en MIDI player with a terminal interface
+.SH SYNOPSIS
+.B fmidi\-play
+.RI [ OPTION \ ...]
+.I INPUT
+.RI [ INPUT \ ...]
+.P
+Plays the specified MIDI file or files with an interactive terminal interface.
+.SH OPTIONS
+.TP
+.B \-r
+Play
+.I INPUT
+files in random order.
+.TP
+.B \-n\fR\ \fINAME
+Specify MIDI client name (default
+.RB \(lq fmidi \(rq).
+.TP
+.B \-M\ \fR[\fBalsa\fR|\fBjack\fR]
+Choose a particular MIDI API for playback; default is unspecified, allowing the
+RtMidi library to choose.
+.TP
+.B \-L\fR\ \fILOG
+Write a playback log to the given
+.I LOG
+file path.
+.SH "SEE\ ALSO"
+.BR fmidi\-convert (1),
+.BR fmidi\-grep (1),
+.BR fmidi\-read (1),
+.BR fmidi\-seq (1)

--- a/man/fmidi-read.1
+++ b/man/fmidi-read.1
@@ -1,0 +1,27 @@
+.TH FMIDI\-READ "1" "August 2021" "" "User Commands"
+.SH NAME
+fmidi\-read \(en validate MIDI files
+.SH SYNOPSIS
+.B fmidi\-read
+.I INPUT
+.RI [ INPUT \ ...]
+.P
+Reads each
+.I INPUT
+file and prints any errors.
+.SH "EXIT\ STATUS"
+.TP
+.B 0
+if all
+.I INPUT
+files were free of errors
+.TP
+.B 1
+if any error was reported in an
+.I INPUT
+file
+.SH "SEE\ ALSO"
+.BR fmidi\-convert (1),
+.BR fmidi\-grep (1),
+.BR fmidi\-play (1),
+.BR fmidi\-seq (1)

--- a/man/fmidi-read.1
+++ b/man/fmidi-read.1
@@ -1,6 +1,6 @@
 .TH FMIDI\-READ "1" "August 2021" "" "User Commands"
 .SH NAME
-fmidi\-read \(en validate MIDI files
+fmidi\-read \(en print a textual representation of a music file
 .SH SYNOPSIS
 .B fmidi\-read
 .I INPUT
@@ -8,18 +8,18 @@ fmidi\-read \(en validate MIDI files
 .P
 Reads each
 .I INPUT
-file and prints any errors.
+file and prints a textual s-expression representation.
 .SH "EXIT\ STATUS"
 .TP
 .B 0
 if all
 .I INPUT
-files were free of errors
+files were successfully read
 .TP
 .B 1
-if any error was reported in an
+if any
 .I INPUT
-file
+file could not be read; the file in question may be broken beyond repair
 .SH "SEE\ ALSO"
 .BR fmidi\-convert (1),
 .BR fmidi\-grep (1),

--- a/man/fmidi-seq.1
+++ b/man/fmidi-seq.1
@@ -1,14 +1,18 @@
 .TH FMIDI\-SEQ "1" "August 2021" "" "User Commands"
 .SH NAME
-fmidi\-seq \(en print the complete sequence from a MIDI file
+fmidi\-seq \(en a MIDI sequencer
 .SH SYNOPSIS
 .B fmidi\-seq
 .I INPUT
 .P
-Reads the
+From the
 .I INPUT
-file and prints the MIDI sequence on
-.BR stdout .
+file,
+.BR fmidi\-seq (1)
+calculates the precise time in seconds where individual MIDI events would occur
+in playback, producing a textual output.
+The result is structured as an S-expression; each event is represented as a
+tuple of the track number, the time (offset) in seconds, and the MIDI event.
 .SH "SEE\ ALSO"
 .BR fmidi\-convert (1),
 .BR fmidi\-grep (1),

--- a/man/fmidi-seq.1
+++ b/man/fmidi-seq.1
@@ -1,0 +1,16 @@
+.TH FMIDI\-SEQ "1" "August 2021" "" "User Commands"
+.SH NAME
+fmidi\-seq \(en print the complete sequence from a MIDI file
+.SH SYNOPSIS
+.B fmidi\-seq
+.I INPUT
+.P
+Reads the
+.I INPUT
+file and prints the MIDI sequence on
+.BR stdout .
+.SH "SEE\ ALSO"
+.BR fmidi\-convert (1),
+.BR fmidi\-grep (1),
+.BR fmidi\-play (1),
+.BR fmidi\-read (1)


### PR DESCRIPTION
Man page content based on reading the sources for the command-line tools but otherwise written from a position of ignorance. Edits welcome.

Installs into hard-coded `$PREFIX/share/man/man1` when the corresponding tool is built. There may be a better way to handle this; suggestions also welcome.